### PR TITLE
Fix Millificent Golden Buddy deathrattle

### DIFF
--- a/src/simulation/deathrattle-effects.ts
+++ b/src/simulation/deathrattle-effects.ts
@@ -195,7 +195,7 @@ export const handleDeathrattleEffects = (
 						otherBoard,
 						otherBoardHero,
 						deadEntity,
-						8,
+						6,
 						boardWithDeadEntity,
 						boardWithDeadEntityHero,
 						allCards,


### PR DESCRIPTION
Millificent's buddy was nerfed from 4 -> 3 damage in patch 22.2 but the golden buddy was not correctly updated to be 6 instead of 8 damage.