### PR TITLE
PalescaleCrocolisk won't apply avenge and dethrattle effect on itself.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -306,7 +306,10 @@ export const grantRandomStats = (
 	spectator: Spectator,
 ): BoardEntity => {
 	if (board.length > 0) {
-		const validBeast: BoardEntity = getRandomAliveMinion(board, race, allCards);
+		const validBeast: BoardEntity = getRandomAliveMinion(
+			board.filter((e) => e.entityId !== source.entityId), race, allCards);
+		//tmp fix for PalescaleCrocolisk, PalescaleCrocolisk won't apply avenge and dethrattle effect on itself. 
+		//const validBeast: BoardEntity = getRandomAliveMinion(board, race, allCards);
 		if (validBeast) {
 			modifyAttack(validBeast, attack, board, allCards);
 			modifyHealth(validBeast, health, board, allCards);


### PR DESCRIPTION
testd with board below

`{
    "playerBoard": {
        "player": {
            "tavernTier": 4,
            "hpLeft": 4,
            "cardId": "TB_BaconShop_HERO_90",
            "nonGhostCardId": "TB_BaconShop_HERO_90",
            "heroPowerId": "TB_BaconShop_HP_101",
            "heroPowerUsed": false,
            "heroPowerInfo": 11
        },
        "secrets": [],
        "board": [{
                "cardId": "TB_BaconUps_135",
                "attack": 10,
                "divineShield": false,
                "enchantments": [],
                "entityId": 3145,
                "health": 6,
                "poisonous": false,
                "reborn": false,
                "taunt": false,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }, {
                "cardId": "TB_BaconUps_119",
                "attack": 29,
                "divineShield": false,
                "enchantments": [{
                        "originEntityId": 3909,
                        "cardId": "BGS_059e"
                    }, {
                        "originEntityId": 3910,
                        "cardId": "BGS_059e"
                    }, {
                        "originEntityId": 3931,
                        "cardId": "BGS_059e"
                    }, {
                        "originEntityId": 4000,
                        "cardId": "BGS_083e"
                    }
                ],
                "entityId": 3908,
                "health": 29,
                "poisonous": false,
                "reborn": false,
                "taunt": false,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }, {
                "cardId": "DMF_533",
                "attack": 6,
                "divineShield": false,
                "enchantments": [],
                "entityId": 3967,
                "health": 4,
                "poisonous": false,
                "reborn": false,
                "taunt": true,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }, {
                "cardId": "BGS_083",
                "attack": 3,
                "divineShield": false,
                "enchantments": [],
                "entityId": 3808,
                "health": 3,
                "poisonous": false,
                "reborn": false,
                "taunt": false,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }, {
                "cardId": "BG21_001",
                "attack": 6,
                "divineShield": false,
                "enchantments": [{
                        "originEntityId": 4001,
                        "cardId": "BGS_083e"
                    }
                ],
                "entityId": 3149,
                "health": 7,
                "poisonous": false,
                "reborn": false,
                "taunt": false,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }, {
                "cardId": "FP1_031",
                "attack": 1,
                "divineShield": false,
                "enchantments": [],
                "entityId": 3939,
                "health": 7,
                "poisonous": false,
                "reborn": false,
                "taunt": false,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }
        ]
    },
    "opponentBoard": {
        "player": {
            "tavernTier": 5,
            "hpLeft": 33,
            "cardId": "BG21_HERO_020",
            "nonGhostCardId": "BG21_HERO_020",
            "heroPowerId": "BG21_HERO_020p",
            "heroPowerUsed": false,
            "heroPowerInfo": 3
        },
        "secrets": [],
        "board": [{
                "cardId": "BG22_001",
                "attack": 17,
                "divineShield": false,
                "enchantments": [{
                        "originEntityId": 4305,
                        "cardId": "BG20_HERO_201e3"
                    }, {
                        "originEntityId": 4306,
                        "cardId": "BG_CFM_063e"
                    }
                ],
                "entityId": 4304,
                "health": 17,
                "poisonous": false,
                "reborn": false,
                "taunt": false,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }, {
                "cardId": "BGS_202",
                "attack": 12,
                "divineShield": false,
                "enchantments": [{
                        "originEntityId": 4308,
                        "cardId": "BGS_202e"
                    }
                ],
                "entityId": 4307,
                "health": 12,
                "poisonous": false,
                "reborn": false,
                "taunt": false,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }, {
                "cardId": "BG23_011",
                "attack": 8,
                "divineShield": false,
                "enchantments": [{
                        "originEntityId": 4310,
                        "cardId": "BG23_011e"
                    }, {
                        "originEntityId": 4311,
                        "cardId": "BG23_011e"
                    }, {
                        "originEntityId": 4312,
                        "cardId": "BG23_006e"
                    }, {
                        "originEntityId": 4313,
                        "cardId": "BG20_HERO_201e3"
                    }, {
                        "originEntityId": 4314,
                        "cardId": "BG_CFM_063e"
                    }
                ],
                "entityId": 4309,
                "health": 16,
                "poisonous": false,
                "reborn": false,
                "taunt": false,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }, {
                "cardId": "BGS_060",
                "attack": 13,
                "divineShield": false,
                "enchantments": [{
                        "originEntityId": 4316,
                        "cardId": "BGS_110e"
                    }, {
                        "originEntityId": 4317,
                        "cardId": "BGS_110e"
                    }, {
                        "originEntityId": 4318,
                        "cardId": "BGS_110e"
                    }, {
                        "originEntityId": 4319,
                        "cardId": "BGS_110e"
                    }
                ],
                "entityId": 4315,
                "health": 5,
                "poisonous": false,
                "reborn": false,
                "taunt": true,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }, {
                "cardId": "DMF_533",
                "attack": 6,
                "divineShield": false,
                "enchantments": [],
                "entityId": 4320,
                "health": 4,
                "poisonous": false,
                "reborn": false,
                "taunt": true,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }, {
                "cardId": "BG23_011",
                "attack": 2,
                "divineShield": false,
                "enchantments": [],
                "entityId": 4321,
                "health": 2,
                "poisonous": false,
                "reborn": false,
                "taunt": false,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }, {
                "cardId": "BG23_014",
                "attack": 4,
                "divineShield": false,
                "enchantments": [],
                "entityId": 4322,
                "health": 5,
                "poisonous": false,
                "reborn": false,
                "taunt": false,
                "windfury": false,
                "megaWindfury": false,
                "friendly": true,
                "frenzyApplied": false,
                "definitelyDead": false,
                "immuneWhenAttackCharges": 0
            }
        ]
    },
    "options": {
        "numberOfSimulations": 1112.5,
        "maxAcceptableDuration": 6000
    },
    "gameState": {
        "currentTurn": 0
    }
}`


before:

  console.log
    result {
      wonLethal: 0,
      won: 4234,
      tied: 0,
      lost: 0,
      lostLethal: 0,
      damageWon: 47064,
      damageLost: 0,
      wonLethalPercent: 0,
      wonPercent: 100,
      tiedPercent: 0,
      lostPercent: 0,
      lostLethalPercent: 0,
      averageDamageWon: 11.115729806329712,
      averageDamageLost: 0,
      outcomeSamples: undefined
    }



after:

  console.log
    result {
      wonLethal: 0,
      won: 12,
      tied: 35,
      lost: 5706,
      lostLethal: 5706,
      damageWon: 108,
      damageLost: 74114,
      wonLethalPercent: 0,
      wonPercent: 0.2,
      tiedPercent: 0.5999999999999972,
      lostPercent: 99.2,
      lostLethalPercent: 99.2,
      averageDamageWon: 9,
      averageDamageLost: 12.988783736417806,
      outcomeSamples: undefined
    }